### PR TITLE
fix follow button hidden on mobile

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,5 +57,6 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
+  max-width: 100%;
+  width: 100%;
 }


### PR DESCRIPTION
Follow Component has a min width of 800px which causes overflow on mobile